### PR TITLE
Results protocol

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/test.check "0.9.0"]]
+                 [org.clojure/test.check "1.1.0"]]
   :test-selectors {:default #(not (:interactive %))
                    :interactive :interactive}
   :repositories [["releases" {:url "https://clojars.org/repo"

--- a/test/stateful_check/core_test.clj
+++ b/test/stateful_check/core_test.clj
@@ -191,7 +191,7 @@
   `(let [message# (volatile! nil)]
      (with-redefs [clojure.test/do-report
                    (fn [details#]
-                     (assert (= (:type details#) :fail))
+                     (assert (= (:type details#) :error))
                      (vreset! message# (:message details#)))]
        ~@body
        @message#)))


### PR DESCRIPTION
Hi @czan,

I thought before designing the data structures for the debugger I
first take a look what has changed in test.check recently with regards
to error reporting, and here is what I discovered.

Newer versions of Clojure test.check have a Results protocol [1]. What
this protocol allows is to return additional data from a property,
instead of just true or false. If we are using this protocol, we could
get rid of the stateful-check failure exception machinery.

This has the benefit of having more readable test.check reports
returned by run-specification. The values under the :result key and
the :shrunk :smallest keys are no longer exceptions (with a long
stacktrace attached to them, that makes it hard to read), but the
plain result-data instead, which is basically the ex-data of the
failure expression.

I think with this change, and some further tweaks to the error
reporting, we could leaverage more of CIDER and Clojure Test error
reporting functionality. I think we should look more closely to how
clojure.test.check.clojure-test is reporing, which I plan to do in
maybe another PR?

Wdyt?
