### PR TITLE
Include commands that did not run when printing frequencies

### DIFF
--- a/src/stateful_check/core.clj
+++ b/src/stateful_check/core.clj
@@ -301,7 +301,8 @@
   [msg [_ specification options]]
   `(let [spec# ~specification
          options# ~options
-         [results# frequencies#] (binding [*run-commands* (atom {})]
+         run-commands# (->> spec# :commands keys (into {} (map #(vector % 0))))
+         [results# frequencies#] (binding [*run-commands* (atom run-commands#)]
                                    [(run-specification spec# options#)
                                     @*run-commands*])]
      (report-result ~msg spec# options# results# frequencies#)))

--- a/test/stateful_check/core_test.clj
+++ b/test/stateful_check/core_test.clj
@@ -239,3 +239,12 @@
 
 (deftest nested-symbolic-values-get-resolved-correctly
   (is (specification-correct? {:commands {:make-tree #'make-tree-command}})))
+
+(deftest report-zero-frequencies-test
+  (let [output (with-out-str
+                 (is (specification-correct?
+                      (assoc-in small-set-spec [:commands :never]
+                                {:command #(assert false)
+                                 :requires (constantly false)})
+                      {:report {:command-frequency? true}})))]
+    (is (re-matches #"(?s).*|\s+:never\s+|\s+0\s+|.*" output))))


### PR DESCRIPTION
Hi @czan,

I'm back!

I also faced the problem of a command not being executed and not noticing it for a while. This change prints commands that did not run when printing frequencies.

It is a partial solution to the issue raised here in https://github.com/czan/stateful-check/issues/18

Before, the frequencies table did only include the command that were run with their counts. If you have many commands it is not easy to spot if some haven't been run.

```
|   :command | :count |
|------------+--------|
|       :add |    112 |
|    :remove |    108 |
| :contains? |    107 |
```

After this change, all command frequencies are reported, with the ones that did not run at the bottom.

```
|   :command | :count |
|------------+--------|
|       :add |    112 |
|    :remove |    108 |
| :contains? |    107 |
|     :never |      0 |
```

Can we add this?